### PR TITLE
Adds string accepting seed function and more control of logging and seeding

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,11 @@ class Template {
     return template(this._template, vars);
   }
 }
+
+// temporarily overwrite faker with old style methods
+faker.random.number = function() { return faker.datatype.number(...arguments) };
+faker.random.boolean = function() { return faker.datatype.boolean(...arguments) };
+
 //
 const locationFactory = require('./location/factory.js');
 const vars = require('./vars/index.js');
@@ -65,10 +70,8 @@ module.exports = function(seed, path, reader, $, resolve) {
       resolver(resolve, path),
       finder(reader, path),
       renderer(
-        vars(locationFactory(), range, $),
         Template,
-        faker,
-        seed
+        vars(locationFactory(), range, $, faker, seed)
       ),
       YAML,
       mutate

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -40,10 +40,11 @@ module.exports = function(resolve, find, render, YAML, mutate) {
           method: request.method,
           cookies: request.cookies,
         };
-        log(`${request.method.toUpperCase()}: ${request.url}`);
+        if((request.cookies['HC_API_DOUBLE_LOG'] || '').length > 0) {
+          log(`${request.method.toUpperCase()}: ${request.url}`);
+        }
         config = getConfig(Object.assign({}, vars, { content: obj.config }));
         config = makeConfig(config, request.method, request.query);
-
         return render(Object.assign({}, vars, { content: obj.content }));
       })
       .then(function(result) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,23 +1,5 @@
-module.exports = function(getVars, Template, fake, seed) {
-  if (typeof seed === 'undefined') {
-    seed = fake.random.number();
-  } else {
-    seed = parseInt(seed);
-  }
+module.exports = function(Template, getVars) {
   return function(vars) {
-    const template = new Template(vars.content.toString());
-    fake.seed(seed);
-    const result = template.render(
-      getVars(
-        Object.assign(
-          {
-            fake: fake,
-          },
-          vars
-        )
-      )
-    );
-    fake.seed(seed);
-    return result;
+    return new Template(vars.content.toString()).render(getVars(vars));
   };
 };

--- a/vars/index.js
+++ b/vars/index.js
@@ -1,8 +1,34 @@
-module.exports = function(locationFactory, range, env) {
+module.exports = function(locationFactory, range, env, fake) {
   env = typeof env === 'undefined' ? process.env : env;
   return function(vars) {
+    if((vars.cookies['HC_API_DOUBLE_LOCALE'] || '').length > 0) {
+      fake.locale = vars.cookies['HC_API_DOUBLE_LOCALE'];
+    }
+    if (typeof seed === 'undefined') {
+      seed = fake.datatype.number();
+    } else {
+      seed = parseInt(seed);
+    }
+    if((vars.cookies['HC_API_DOUBLE_SEED'] || '').length > 0) {
+      seed = vars.cookies['HC_API_DOUBLE_SEED'];
+    }
+
+    // helper to get a deterministic number from a string if it isn't already a number
+    const seedStr = function(s) {
+      if(!isNaN(s)) {
+        return parseInt(s);
+      }
+      for(var i = 0, h = 0xdeadbeef; i < s.length; i++)
+          h = Math.imul(h ^ s.charCodeAt(i), 2654435761);
+      return (h ^ h >>> 16) >>> 0;
+    };
+    fake.seed(seedStr(seed));
     return Object.assign(vars, {
+      fake: fake,
       location: locationFactory(vars.href, vars.query),
+      seed: function(seed) {
+        fake.seed(seedStr(seed));
+      },
       range: function(a, b) {
         if (typeof b !== 'undefined') {
           b = parseInt(b);


### PR DESCRIPTION
This PR does a number of things:

1. Adds some new environment variables to enable toggling of logging, faker locales, and controlling the faker seed.
2. The new faker upgrade came with a few deprecation warnings, so we work around those for the moment to avoid having to search/replace an entire API double codebase.
3. Adds a `seed` function, which is now available in API doubles, that can be used for setting the seed either permanently for the request or temporarily. This seed function also accepts strings (which are converted to a numeric faker seed) to enable relationships across multiple API requests whilst keeping the entire API double stateless.